### PR TITLE
#41 冗長なピリオドがbot返信に付与された事象を修正

### DIFF
--- a/src/main/java/com/github/graycat27/atc/components/bot/TwrBot.java
+++ b/src/main/java/com/github/graycat27/atc/components/bot/TwrBot.java
@@ -19,6 +19,7 @@ public class TwrBot extends AtcBot {
 
         if(receivedBody.contains("request ")){
             String requestedThing = received.substring(receivedBody.indexOf("request ")+ "request ".length());
+            requestedThing = requestedThing.trim();
             if(!requestedThing.endsWith(".")){
                 requestedThing += ".";
             }

--- a/src/test/java/com/github/graycat27/atc/handler/event/AtcRadioListenHandlerTest.java
+++ b/src/test/java/com/github/graycat27/atc/handler/event/AtcRadioListenHandlerTest.java
@@ -97,4 +97,18 @@ class AtcRadioListenHandlerTest {
         assertEquals("cleared for landing.", result.getResponseBody());
     }
 
+    @Test
+    public void testRequestResponseNoPeriodTwr(){
+        AtcMessageData result = analyzeMessageTester(Control.TWR,
+                "twr, gray27. we request landing");
+        assertEquals("cleared for landing.", result.getResponseBody());
+    }
+
+    @Test
+    public void testRequestResponseLongRequestTwr(){
+        AtcMessageData result = analyzeMessageTester(Control.TWR,
+                "twr, gray27. we request approach and fly over rwy");
+        assertEquals("cleared for approach and fly over rwy.", result.getResponseBody());
+    }
+
 }

--- a/src/test/java/com/github/graycat27/atc/handler/event/AtcRadioListenHandlerTest.java
+++ b/src/test/java/com/github/graycat27/atc/handler/event/AtcRadioListenHandlerTest.java
@@ -90,4 +90,11 @@ class AtcRadioListenHandlerTest {
         assertEquals("loud and clear." ,result.getResponseBody());
     }
 
+    @Test
+    public void testRequestResponseTwr(){
+        AtcMessageData result = analyzeMessageTester(Control.TWR,
+                "twr, gray27. we request landing.");
+        assertEquals("cleared for landing.", result.getResponseBody());
+    }
+
 }


### PR DESCRIPTION
fix #41 